### PR TITLE
feat: add toggle visibility for password input on login form

### DIFF
--- a/account/login.html
+++ b/account/login.html
@@ -58,6 +58,7 @@
 
 
     <main>
+        <h1 style="display: none;">Hei</h1>
         <span class="loader" id="loader"></span>
 
         <section class="login-container">
@@ -65,7 +66,6 @@
                 <img src="/image/login/Image.jpg" alt="Rear view of a vehicle driving on a road">
             </div>
             <form class="login-form" id="login-form" method="POST">
-
                 <h2>Log in</h2>
 
                 <label class="label" for="name">User name</label>
@@ -73,7 +73,13 @@
                 <label class="label" for="email">Email address</label>
                 <input type="email" name="email" id="email" placeholder="Enter your email address" required>
                 <label class="label" for="Password">Password</label>
-                <input type="password" name="password" id="password" placeholder="Password" required>
+                <div class="password-wrapper">
+                    <input type="password" name="password" id="password" placeholder="Password" required>
+                    <button type="button" id="togglePassword" class="togglePassword"
+                        aria-label="Toggle password visibility">
+                        👁️
+                    </button>
+                </div>
                 <p>By continuing, you agree to the <span>Terms</span> of use and <span>Privacy Policy.</span></p>
                 <div class="robot-check">
                     <input class="not-robot" type="checkbox" id="notRobot" required>

--- a/account/register.html
+++ b/account/register.html
@@ -37,6 +37,7 @@
     </header>
 
     <main>
+        <h1 style="display: none;">Hei</h1>
         <span class="loader" id="loader"></span>
 
         <section class="login-container">
@@ -53,13 +54,22 @@
                 <input type="email" name="email" id="email" placeholder="Enter your email address" required>
 
                 <label class="label" for="password">Password</label>
-                <input type="password" name="password" id="password" placeholder="Create a password" required
-                    minlength="7">
-
+                <div class="password-wrapper">
+                    <input type="password" name="password" id="password" placeholder="Create a password" required
+                        minlength="7">
+                    <button type="button" id="togglePassword" class="togglePassword"
+                        aria-label="Toggle password visibility">
+                        👁️
+                    </button>
+                </div>
                 <label class="label" for="confirm-password">Confirm Password</label>
-                <input type="password" name="confirm-password" id="confirm-password"
-                    placeholder="Re-enter your password" required>
-
+                <div class="password-wrapper">
+                    <input type="password" name="password" id="confirm-password" placeholder="Re-enter your password"" required>
+                    <button type=" button" id="toggleConfirmPassword" class="togglePassword"
+                        aria-label="Toggle password visibility">
+                    👁️
+                    </button>
+                </div>
                 <p>By continuing, you agree to the <span>Terms</span> of use and <span>Privacy Policy.</span></p>
 
                 <div class="robot-check">

--- a/css/common-css.css
+++ b/css/common-css.css
@@ -366,6 +366,46 @@ h1 {
             }
         }
 
+        .password-wrapper {
+            position: relative;
+            display: flex;
+            align-items: center;
+
+            input {
+                flex: 1;
+                padding-right: 2.5rem;
+                height: 2.5rem;
+                width: 100%;
+                border: 1px solid #c5c5c5;
+                border-radius: 0.3rem;
+                padding-left: 1rem;
+                margin-bottom: 1rem;
+                font-size: 1rem;
+
+                &::placeholder {
+                    color: #ccc;
+                }
+            }
+
+            .togglePassword {
+                position: absolute;
+                right: 1rem;
+                bottom: 0.5rem;
+                background: none;
+                border: none;
+                cursor: pointer;
+                font-size: 1.1rem;
+                color: #666;
+                height: 100%;
+                display: flex;
+                align-items: center;
+
+                &:hover {
+                    color: #000;
+                }
+            }
+        }
+
         .submit {
             background: var(--color-button-bg);
             color: #ffffff;

--- a/js/index.mjs
+++ b/js/index.mjs
@@ -18,7 +18,7 @@ if (username === null) {
 export const fetchblogs = `https://v2.api.noroff.dev/blog/posts/${username}/`;
 let allPosts = [];
 let currentPage = 1;
-const postsPerPage = 9;
+const postsPerPage = 12;
 let filteredPosts = [];
 
 fetchPosts();

--- a/js/login.mjs
+++ b/js/login.mjs
@@ -6,6 +6,16 @@ const nameInput = document.querySelector('#name');
 const emailInput = document.querySelector('#email');
 const passwordInput = document.querySelector('#password');
 const loader = document.getElementById('loader');
+const togglePasswordBtn = document.querySelector('.togglePassword');
+
+if (togglePasswordBtn && passwordInput) {
+  togglePasswordBtn.addEventListener('click', () => {
+    const type =
+      passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
+    passwordInput.setAttribute('type', type);
+    togglePasswordBtn.textContent = type === 'password' ? '👁️' : '🙈';
+  });
+}
 
 loginForm.addEventListener('submit', (event) => {
   event.preventDefault();

--- a/js/register.mjs
+++ b/js/register.mjs
@@ -7,6 +7,30 @@ const emailInput = document.querySelector('#email');
 const passwordInput = document.querySelector('#password');
 const confirmPasswordInput = document.querySelector('#confirm-password');
 const loader = document.getElementById('loader');
+const togglePasswordBtn = document.getElementById('togglePassword');
+const toggleConfirmPasswordBtn = document.getElementById(
+  'toggleConfirmPassword'
+);
+
+if (togglePasswordBtn && passwordInput) {
+  togglePasswordBtn.addEventListener('click', () => {
+    const type =
+      passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
+    passwordInput.setAttribute('type', type);
+    togglePasswordBtn.textContent = type === 'password' ? '👁️' : '🙈';
+  });
+}
+
+if (toggleConfirmPasswordBtn && confirmPasswordInput) {
+  toggleConfirmPasswordBtn.addEventListener('click', () => {
+    const type =
+      confirmPasswordInput.getAttribute('type') === 'password'
+        ? 'text'
+        : 'password';
+    confirmPasswordInput.setAttribute('type', type);
+    toggleConfirmPasswordBtn.textContent = type === 'password' ? '👁️' : '🙈';
+  });
+}
 
 registerForm.addEventListener('submit', (event) => {
   event.preventDefault();

--- a/post/create.html
+++ b/post/create.html
@@ -58,9 +58,9 @@
     </header>
 
     <main>
+        <h1 style="display: none;">Hei</h1>
 
         <span class="loader" id="loader"></span>
-
         <div class="create-new-post-component">
 
             <form id="postForm">

--- a/post/edit.html
+++ b/post/edit.html
@@ -55,6 +55,7 @@
     </header>
 
     <main>
+        <h1 style="display: none;">Hei</h1>
         <span class="loader" id="loader"></span>
 
         <div class="create-new-post-component">

--- a/post/single.html
+++ b/post/single.html
@@ -58,6 +58,7 @@
 
 
     <main>
+        <h1 style="display: none;">Hei</h1>
 
         <section id="singe-post-container"></section>
 


### PR DESCRIPTION
Implemented a toggle feature for the password field on the login page.

- Added an eye icon next to the password input
- Enabled switching input type between 'password' and 'text'
- Updated icon dynamically to reflect current state (visible/hidden)
- Improved accessibility with aria-label for screen readers
- Ensured responsiveness across devices

This enhancement improves usability and allows users to verify their password before submission.

<img width="526" alt="image" src="https://github.com/user-attachments/assets/43ab234e-d45b-43c9-adfe-5016655b777c" />
